### PR TITLE
react-copy-write: render functions can be `null` and fixes for select prop

### DIFF
--- a/types/react-copy-write/index.d.ts
+++ b/types/react-copy-write/index.d.ts
@@ -17,10 +17,10 @@ type MutateFn<T> = (draft: T) => void;
 type Mutator<T> = (mutator: MutateFn<T>) => void;
 
 // any instead of T due to selector
-type RenderFn<T> = (state: any, mutate: MutateFn<T>) => JSX.Element | JSX.Element[];
+type RenderFn<T> = (state: any, mutate: MutateFn<T>) => JSX.Element | JSX.Element[] | null;
 
 interface ConsumerProps<T> {
-    selector?: (state: T) => any;
+    select?: ((state: T) => any)[];
     render?: RenderFn<T>;
     children?: RenderFn<T>;
 }


### PR DESCRIPTION
* Render functions can be `null`
* `selector` is named `select` now. Also I believe it should take an array of selectors.

Apologies for the messy combined PR, I'm on a laptop where I don't have Git set up so I had to do it through the GitHub interface.